### PR TITLE
New TransactionSlider, bug and lint fixes

### DIFF
--- a/components/AssetBalance.tsx
+++ b/components/AssetBalance.tsx
@@ -25,7 +25,6 @@ const AssetBalance: React.FC<AssetBalanceProps> = ({ setBalanceError }) => {
     if (userAssets) {
       if (asset === "MATIC") {
         let formattedAsset = userAssets["ETH"]?.formatted;
-        console.log(formattedAsset);
         return Number(formattedAsset).toFixed(4);
       } else {
         let { ...address } = userAssets;
@@ -38,26 +37,29 @@ const AssetBalance: React.FC<AssetBalanceProps> = ({ setBalanceError }) => {
   };
   const displayBalance = balance();
 
-  /**
-   * @remarks - pass boolean to parent component TransferForm. If balance < amount, return true and display error message in TransferForm. Loading indicator shows if API call lags
-   * @param amount - user generated asset amount from input. Taken from FormContext
-   * @param balance - balance of asset
-   * @returns boolean value comparing amount to balance
-   */
-  const compareBalanceToInput = (
-    amount: number | undefined,
-    balance: number
-  ): void => {
-    if (amount && displayBalance) {
-      if (balance < amount) {
-        setBalanceError(true);
-      } else {
-        setBalanceError(false);
+  useEffect(() => {
+    /**
+     * @remarks - pass boolean to parent component TransferForm. If balance < amount, return true and display error message in TransferForm. Loading indicator shows if API call lags
+     * @param amount - user generated asset amount from input. Taken from FormContext
+     * @param balance - balance of asset
+     * @returns boolean value comparing amount to balance
+     */
+    const compareBalanceToInput = (
+        amount: number | undefined,
+        balance: number
+    ): void => {
+      if (amount && displayBalance) {
+        if (balance < amount) {
+          setBalanceError(true);
+        } else {
+          setBalanceError(false);
+        }
       }
-    }
-  };
+    };
 
-  compareBalanceToInput(amount, Number(displayBalance));
+    compareBalanceToInput(amount, Number(displayBalance));
+  }, [amount, displayBalance, setBalanceError])
+
 
   useEffect(() => {
     const ACCESS_TOKEN = session?.user.accessToken;
@@ -75,7 +77,6 @@ const AssetBalance: React.FC<AssetBalanceProps> = ({ setBalanceError }) => {
     axios
       .get(asset === "MATIC" ? urlMATIC : urlNotMATIC, options)
       .then((response) => {
-        console.log("response", Object.values(response.data));
         setUserAssets(response.data);
         setIsLoading(false);
       })

--- a/components/AssetBalance.tsx
+++ b/components/AssetBalance.tsx
@@ -17,6 +17,7 @@ interface AssetBalanceProps {
 const AssetBalance: React.FC<AssetBalanceProps> = ({ setBalanceError }) => {
   const [userAssets, setUserAssets] = useState<UserBalance | undefined>();
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
   const { asset, amount } = useFormContext();
   const { data: session } = useSession();
   const tokenAddress = supportedAssets[asset];
@@ -80,6 +81,10 @@ const AssetBalance: React.FC<AssetBalanceProps> = ({ setBalanceError }) => {
         setIsLoading(false);
       })
       .catch((error) => {
+        if (error?.response?.status === 401) {
+          setError('Authentication error. Please log in again.')
+        }
+        setIsLoading(false);
         console.error(error);
       });
     // eslint-disable-next-line
@@ -103,7 +108,7 @@ const AssetBalance: React.FC<AssetBalanceProps> = ({ setBalanceError }) => {
       )}
       <Text
         display={isLoading ? "none" : "block"}
-      >{`${"$"}${displayBalance} ${asset}`}</Text>
+      >{displayBalance ? `${"$"}${displayBalance} ${asset}` : `${error || 'Error'}`}</Text>
     </Box>
   );
 };

--- a/components/AssetBalance.tsx
+++ b/components/AssetBalance.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, Image, Text } from "@chakra-ui/react";
 import axios from "axios";
 import { useFormContext } from "context/FormContext";
-import { useSession } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 import React, { Dispatch, useEffect, useState } from "react";
 import { UserBalance } from "types/keypEndpoints";
 import { supportedAssets } from "utils/general";
@@ -17,7 +17,6 @@ interface AssetBalanceProps {
 const AssetBalance: React.FC<AssetBalanceProps> = ({ setBalanceError }) => {
   const [userAssets, setUserAssets] = useState<UserBalance | undefined>();
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState('');
   const { asset, amount } = useFormContext();
   const { data: session } = useSession();
   const tokenAddress = supportedAssets[asset];
@@ -82,7 +81,7 @@ const AssetBalance: React.FC<AssetBalanceProps> = ({ setBalanceError }) => {
       })
       .catch((error) => {
         if (error?.response?.status === 401) {
-          setError('Authentication error. Please log in again.')
+          signOut()
         }
         setIsLoading(false);
         console.error(error);
@@ -108,7 +107,7 @@ const AssetBalance: React.FC<AssetBalanceProps> = ({ setBalanceError }) => {
       )}
       <Text
         display={isLoading ? "none" : "block"}
-      >{displayBalance ? `${"$"}${displayBalance} ${asset}` : `${error || 'Error'}`}</Text>
+      >{displayBalance ? `${"$"}${displayBalance} ${asset}` : 'Error'}</Text>
     </Box>
   );
 };

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -95,7 +95,7 @@ const Navbar = () => {
               </Tooltip>
             </HStack>
 
-            <Box pl={["0.25rem", "1rem"]} onClick={() => signOut()}>
+            <Box pl={["0.25rem", "1rem"]} onClick={() => signOut()} cursor="pointer" _hover={{ opacity: 0.5 }}>
               <Text>Sign Out</Text>
             </Box>
           </HStack>

--- a/components/ReviewTransfer.tsx
+++ b/components/ReviewTransfer.tsx
@@ -242,9 +242,9 @@ const ReviewTransfer = () => {
                 <Box mt="-3.15rem" ml="1rem">
                   {/* discord logo */}
                   {platform === "discord" ? (
-                    <FaDiscord color="white" size="2.25rem" />
+                    <FaDiscord color="white" size="36px" />
                   ) : (
-                    <FaGoogle color="white" size="2.25rem" />
+                    <FaGoogle color="white" size="36px" />
                   )}
                 </Box>
               </Box>

--- a/components/ToPlatformSelection.tsx
+++ b/components/ToPlatformSelection.tsx
@@ -41,7 +41,7 @@ const ToPlatformSelection = () => {
         />
         <Box mt="-3.15rem" ml=".9rem">
           {/* Google logo */}
-          <FaGoogle color="white" size="2.25rem" />
+          <FaGoogle color="white" size="36px" />
         </Box>
       </Box>
       <Box
@@ -63,7 +63,7 @@ const ToPlatformSelection = () => {
         />
         <Box mt="-3.15rem" ml="1rem">
           {/* discord logo */}
-          <FaDiscord color="white" size="2.25rem" />
+          <FaDiscord color="white" size="36px" />
         </Box>
       </Box>
     </HStack>

--- a/components/TransactionSlider.tsx
+++ b/components/TransactionSlider.tsx
@@ -20,7 +20,7 @@ const TransactionSlider = () => {
     "Fund",
     "Cash Out",
   ];
-  const { setType, type } = useFormContext();
+  const { setType, type, renderReviewPage, isConfirming } = useFormContext();
   const { setTxSliderHeight } = useSizeProvider();
   const scrollRef = useRef(null);
 
@@ -77,7 +77,7 @@ const TransactionSlider = () => {
 
   return (
       <Flex
-          display={"fixed"}
+          display={renderReviewPage || isConfirming ? "none" : "fixed"}
           ref={scrollRef}
           px={["0rem", "0rem", "5rem"]}
           overflowX="scroll"

--- a/components/TransactionSlider.tsx
+++ b/components/TransactionSlider.tsx
@@ -1,49 +1,74 @@
-import React, { useEffect } from "react";
-import { Box, Button, Flex, HStack, Image } from "@chakra-ui/react";
+import React, { useEffect, useRef } from "react";
+import { Box, Button, Flex } from "@chakra-ui/react";
 import { useFormContext } from "../context/FormContext";
 import { useSizeProvider } from "../context/SizeContext";
 
 /**
  * @remarks - this component is used to determine the "type" of transaction
- * @param setTxSliderHeight - sets the height of the transaction slider. Index.tsx takes this value and passes it to other components to calculate the height of the page
  * @returns - div containing scrollable buttons
  */
 const TransactionSlider = () => {
-  const { setType, type, renderReviewPage, isConfirming } = useFormContext();
+  const cleanedBtnValues = [
+    "send",
+    "request",
+    "fund",
+    "cashout",
+    ];
+  const btnValues = [
+    "Send",
+    "Request",
+    "Fund",
+    "Cash Out",
+  ];
+  const { setType, type } = useFormContext();
   const { setTxSliderHeight } = useSizeProvider();
+  const scrollRef = useRef(null);
 
-  const handletype = (e: any) => {
-    setType(e.target.id);
+  const handleType = (value: any) => {
+    const currentIndex = cleanedBtnValues.indexOf(type);
+    const newIndex = cleanedBtnValues.indexOf(value.toLowerCase().replace(" ", ""));
+    if (currentIndex > newIndex) {
+        // @ts-ignore
+        scrollRef.current.scrollLeft -= 275;
+    } else if (currentIndex === newIndex) {
+
+    } else {
+      if (newIndex === 3) {
+        // Cash Out needs more scroll
+        // @ts-ignore
+        scrollRef.current.scrollLeft += 255;
+      } else {
+        // @ts-ignore
+        scrollRef.current.scrollLeft += 235;
+      }
+    }
+    setType(value.toLowerCase().replace(" ", ""));
   };
 
   const renderButtons = () => {
-    const btnValues = [
-      "Send",
-      "Wallet",
-      "Request",
-      "Fund",
-      "Cash Out",
-      // "Play"
-    ];
-
-    return btnValues.map((value) => {
-      return (
-        <Box key={value}>
-          <Button
-            onClick={handletype}
-            id={value.toLowerCase().replace(" ", "")}
-            variant="none"
-            fontSize="5rem"
-            fontWeight="extrabold"
-            color="formBlueDark"
-            opacity={type === value.toLowerCase().replace(" ", "") ? 1 : 0.5}
-          >
-            {value}
-          </Button>
-        </Box>
-      );
-    });
+    return (
+        <Flex >
+          {btnValues.map((value) => (
+              <Box key={value}>
+                <Button
+                    py={"4rem"}
+                    onClick={() => handleType(value)}
+                    id={value.toLowerCase().replace(" ", "")}
+                    variant="none"
+                    fontSize="5rem"
+                    fontWeight="extrabold"
+                    color="formBlueDark"
+                    opacity={type === value.toLowerCase().replace(" ", "") ? 1 : 0.5}
+                >
+                  {value}
+                </Button>
+              </Box>
+          ))}
+        </Flex>
+    );
   };
+
+
 
   useEffect(() => {
     const txSliderHeight = document.getElementById("txSlider")?.clientHeight;
@@ -51,24 +76,25 @@ const TransactionSlider = () => {
   }, [setTxSliderHeight]);
 
   return (
-    <Flex
-      display={renderReviewPage || isConfirming ? "none" : "flex"}
-      direction="row"
-      mx="-1rem"
-      id="txSlider"
-      px={[0, 0, "5rem"]}
-    >
-      <Box zIndex={1} w={["5rem", "5rem", "5rem", "3rem"]}>
-        <Image src="fade.png" alt="" w="100%" h="full" />
-      </Box>
-      <HStack overflowX="scroll" py="2rem" spacing={-6} mx="-4">
-        {renderButtons()}
-      </HStack>
-      <Box zIndex={1}>
-        <Image src="fade.png" alt="" transform="rotateY(180deg)" h="full" />
-      </Box>
-    </Flex>
+      <Flex
+          display={"fixed"}
+          ref={scrollRef}
+          px={["0rem", "0rem", "5rem"]}
+          overflowX="scroll"
+          direction="row"
+          id="txSlider"
+      >
+        <Flex
+            flex={1}
+            justifyContent="center"
+            alignItems="center"
+            position="relative"
+        >
+          {renderButtons()}
+        </Flex>
+      </Flex>
   );
+
 };
 
 export default TransactionSlider;

--- a/components/TransferForm.tsx
+++ b/components/TransferForm.tsx
@@ -6,12 +6,9 @@ import {
   HStack,
   Input,
   SimpleGrid,
-  Text,
-  Image,
 } from "@chakra-ui/react";
 import { ErrorMessage } from "@hookform/error-message";
 import { FieldValues, useForm } from "react-hook-form";
-import { FaDiscord, FaGoogle } from "react-icons/fa";
 import AssetModal from "./AssetModal";
 import { useFormContext } from "../context/FormContext";
 import ButtonSpacingWrapper from "./ButtonSpacingWrapper";
@@ -29,7 +26,6 @@ const TransferForm = () => {
     type,
     setAmount,
     platform,
-    setPlatform,
     setUsername,
     setRenderTxPage,
     setRenderReviewPage,
@@ -57,10 +53,10 @@ const TransferForm = () => {
     }
   };
 
-  const handleReivew = async (): Promise<void> => {
+  const handleReview = async (): Promise<void> => {
     const stateUpdates = () => {
-      setAmount(values.amount),
-        setUsername(values.username),
+      setAmount(values.amount);
+        setUsername(values.username);
         setRenderTxPage(false);
       setRenderReviewPage(true);
     };
@@ -180,7 +176,7 @@ const TransferForm = () => {
         </GridItem>
       </SimpleGrid>
       <Box mt="2rem" mx="-1.5rem" mb="-1.0rem">
-        <Button onClick={() => handleReivew()} variant="formGray">
+        <Button onClick={() => handleReview()} variant="formGray">
           Review
         </Button>
       </Box>

--- a/hooks/useKeypApi.ts
+++ b/hooks/useKeypApi.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
-import { useSession } from "next-auth/react";
-import { UrlParams1, Endpoints } from "types/keypEndpoints";
+import { Endpoints, UrlParams1 } from "types/keypEndpoints";
 import { Transfers } from "../types/Transfers";
 import { generateEndpointUrl } from "../utils/general";
 
@@ -18,8 +17,8 @@ interface UseKeypApiProps {
  * @param accessToken - from session
  * @param method - request type
  * @param endpoints - endpoint
- * @param urlParam1
- * @param urlParam2
+ * @param urlParams1
+ * @param urlParams2
  * @param data - (optional) arguments for request data
  * @returns
  */
@@ -38,22 +37,20 @@ const UseKeypApi = async ({
     Authorization: "Bearer " + accessToken,
   };
 
-  const fetchData = await axios({
+  return await axios({
     method,
     headers,
     url: endpoint,
     data,
   })
-    .then((response) => {
-      console.log(response.data);
-      return response.data;
-    })
-    .catch((error) => {
-      console.error(error);
-      return error;
-    });
-
-  return fetchData;
+      .then((response) => {
+        console.log(response.data);
+        return response.data;
+      })
+      .catch((error) => {
+        console.error(error);
+        return error;
+      });
 };
 
 export default UseKeypApi;

--- a/pages/_app.css
+++ b/pages/_app.css
@@ -1,0 +1,3 @@
+#txSlider {
+    overflow: hidden;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,24 +6,8 @@ import { theme } from "../theme";
 import { FormProvider } from "../context/FormContext";
 import { SizeProvider } from "../context/SizeContext";
 import Fonts from "../components/Fonts";
+import "./_app.css"
 import "@fontsource/inter";
-// import localFont from "@next/font/local";
-
-// const sharpie = localFont({
-//   src: [
-//     {
-//       path: "../public/fonts/sharpie/Sharpie-Regular.woff2",
-//       weight: "400",
-//     },
-//     {
-//       path: "../public/fonts/sharpie/Sharpie-Extrabold.woff2",
-//       weight: "800",
-//     },
-//   ],
-//   preload: true,
-//   display: "swap",
-// });
-
 interface AppProps {
   Component: any;
   pageProps: any;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -91,7 +91,7 @@ const Login = () => {
               <Box position="absolute" ml="0.65rem">
                 <FaGoogle
                   color={activeBtn === "google" ? "#4285F4" : "white"}
-                  size="1.25rem"
+                  size="20px"
                 />
               </Box>
               <Text ml="1rem">Google</Text>
@@ -127,7 +127,7 @@ const Login = () => {
               >
                 <FaDiscord
                   color={activeBtn === "discord" ? "#5865F2" : "white"}
-                  size="1.25rem"
+                  size="20px"
                 />
               </Box>
               <Text ml="1rem">Discord</Text>


### PR DESCRIPTION
## Description
- New TransactionSlider.tsx: I removed the blur images as we can just use opacity for this effect. I also hide the scrollbar with CSS. Users can click through the buttons and the horizontal scroll happens by manipulating scrollRef

https://user-images.githubusercontent.com/47253537/230677450-82cd685f-2d5c-4288-a453-0b173a110e34.mov

- Added hover effect for sign out button

Bug fixes:
1) user balances: when user balance query returns 401 we log out the user automatically so they can log back in and get a new access token; when user balance query returns an error we set loading to false and set the balance field to be "error"
2) compareBalanceToInput was throwing console errors when the insufficient balance message was triggered because this state change needed to be handled in a useEffect--I moved it and its dependencies to a useEffect hook
3) Converted certain rem values to px because they were throwing console warnings (maybe those elements can't handle rem values?)

Lint fixes: removed some unused constants, typos
